### PR TITLE
Add Contact Form as a seperate Ppage

### DIFF
--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -1,0 +1,129 @@
+import { Button } from '@chakra-ui/button'
+import { FormControl, FormLabel } from '@chakra-ui/form-control'
+import { Input } from '@chakra-ui/input'
+import { Box, SimpleGrid, Stack } from '@chakra-ui/layout'
+import { useRadio, useRadioGroup } from '@chakra-ui/radio'
+import { useColorModeValue } from '@chakra-ui/react'
+import { Textarea } from '@chakra-ui/textarea'
+
+export const ContactForm = (): JSX.Element => {
+  return (
+    <>
+      <SimpleGrid
+        maxW="md"
+        width="700px"
+        px="5"
+        py="2"
+        borderWidth="2px"
+        shadow="sm"
+        borderColor="link"
+        borderRadius="md"
+        textAlign="right"
+      >
+        <Box maxW="full" overflow="hidden" padding={6}>
+          <form
+            name="contact"
+            method="POST"
+            data-netlify="true"
+            data-netlify-honeypot="bot-field"
+          >
+            <input type="hidden" name="form-name" value="contact" />
+            <p hidden>
+              <label>
+                For bots only: <input name="bot-field" />
+              </label>
+            </p>
+
+            <FormControl isRequired mb="1rem">
+              <FormLabel fontWeight="bold">First Name:</FormLabel>
+              <Input name="name" type="text" placeholder="First Name" />
+            </FormControl>
+
+            <ContactReasonControl />
+
+            <FormControl mb="1rem">
+              <FormLabel fontWeight="bold">Your Message:</FormLabel>
+              <Textarea
+                name="message"
+                placeholder="Enter your message here"
+                rows={4}
+              />
+            </FormControl>
+
+            <Button size="lg" mt={4} colorScheme="blue" type="submit">
+              Send Message
+            </Button>
+          </form>
+        </Box>
+      </SimpleGrid>
+    </>
+  )
+}
+
+function ContactReasonControl() {
+  const options = [
+    'I want to hire you',
+    'I want to get to know you',
+    'Could you help me out',
+  ]
+
+  const { getRootProps, getRadioProps } = useRadioGroup({
+    name: 'reason',
+
+    defaultValue: options[0],
+  })
+
+  const group = getRootProps()
+
+  return (
+    <FormControl as="fieldset" mb="1rem">
+      <FormLabel as="legend" fontWeight="bold">
+        Reason for contact:
+      </FormLabel>
+      <Stack {...group} align="start">
+        {options.map((value) => {
+          const radio = getRadioProps({ value })
+
+          return (
+            <RadioOption key={value} {...radio}>
+              {value}
+            </RadioOption>
+          )
+        })}
+      </Stack>
+    </FormControl>
+  )
+}
+
+function RadioOption(props: any) {
+  const { getInputProps, getCheckboxProps } = useRadio(props)
+
+  const input = getInputProps()
+
+  const checkbox = getCheckboxProps()
+
+  const textColor = useColorModeValue('gray.700', 'gray.400')
+
+  return (
+    <Box as="label">
+      <input {...input} />
+
+      <Box
+        {...checkbox}
+        display="inline-block"
+        cursor="pointer"
+        borderWidth="1px"
+        borderRadius="md"
+        color={textColor}
+        _checked={{
+          borderColor: 'link',
+          color: 'link',
+        }}
+        px={4}
+        py={2}
+      >
+        {props.children}
+      </Box>
+    </Box>
+  )
+}

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,3 +1,4 @@
 export { BusinessCard } from './BusinessCard'
 export { Card } from './Card'
 export { ThemeSwitch } from './ThemeSwitch'
+export { ContactForm } from './ContactForm'

--- a/pages/card.tsx
+++ b/pages/card.tsx
@@ -1,0 +1,30 @@
+import Head from 'next/head'
+import { BusinessCard } from '../components'
+
+const borderColorOptions = [
+  'rgb(238,16,16), rgb(252,176,69)',
+  'rgb(255,78,205), rgb(26,117,255)',
+  'rgb(4,91,86), rgb(253,203,73)',
+  'rgb(208,111,63) 60%, rgb(245, 228, 211)',
+]
+
+export default function Card(): JSX.Element {
+  return (
+    <>
+      <Head>
+        <title>Business Card - Petro Silenius</title>
+        <meta name="description" content="Contact information and resume" />
+      </Head>
+
+      <BusinessCard
+        imgSrc="/petro.png"
+        name="Petro Silenius"
+        title="Frontend Developer"
+        borderColors={borderColorOptions[1]}
+        github="petrosilenius"
+        linkedin="petrosilenius"
+        email="petro.silenius@gmail.com"
+      />
+    </>
+  )
+}

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -1,30 +1,22 @@
 import Head from 'next/head'
-import { BusinessCard } from '../components'
+import { Box, Heading } from '@chakra-ui/react'
+import { ContactForm } from '../components'
 
-const borderColorOptions = [
-  'rgb(238,16,16), rgb(252,176,69)',
-  'rgb(255,78,205), rgb(26,117,255)',
-  'rgb(4,91,86), rgb(253,203,73)',
-  'rgb(208,111,63) 60%, rgb(245, 228, 211)',
-]
-
-export default function Card(): JSX.Element {
+export default function About(): JSX.Element {
   return (
     <>
       <Head>
-        <title>Business Card - Petro Silenius</title>
-        <meta name="description" content="Contact information and resume" />
+        <title>About - Petro Silenius</title>
+        <meta name="description" content="Contact form" />
       </Head>
 
-      <BusinessCard
-        imgSrc="/petro.png"
-        name="Petro Silenius"
-        title="Frontend Developer"
-        borderColors={borderColorOptions[1]}
-        github="petrosilenius"
-        linkedin="petrosilenius"
-        email="petro.silenius@gmail.com"
-      />
+      <Box>
+        <Heading textAlign="center" mb="1.5rem">
+          Get in Touch
+        </Heading>
+
+        <ContactForm />
+      </Box>
     </>
   )
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,7 +2,7 @@ import Head from 'next/head'
 import Image from 'next/image'
 import { Card } from '../components'
 import { Heading, SimpleGrid, Text } from '@chakra-ui/react'
-import { Linkedin, GitHub, CreditCard, AlignCenter } from 'react-feather'
+import { Linkedin, GitHub, CreditCard, AlignCenter, Send } from 'react-feather'
 
 export default function Home(): JSX.Element {
   return (
@@ -58,11 +58,17 @@ export default function Home(): JSX.Element {
             Discover some of my freetime projects and completed courses.
           </Text>
         </Card>
-        <Card href="/contact">
+        <Card href="/card">
           <Heading as="h2" size="md" display="flex">
             Business card <CreditCard style={{ marginLeft: '10px' }} />
           </Heading>
           <Text>Check out my business card and generate one for yourself!</Text>
+        </Card>
+        <Card href="/contact">
+          <Heading as="h2" size="md" display="flex">
+            Contact Me <Send style={{ marginLeft: '10px' }} />
+          </Heading>
+          <Text>Get in touch, to hire me, ask for help or just say hi!</Text>
         </Card>
       </SimpleGrid>
     </>


### PR DESCRIPTION
Hi Petro, as discussed I've added the new contact form as a new page on the route `/contact`

![image](https://user-images.githubusercontent.com/45357601/185376663-8bd41409-bea2-40bd-920b-3e6b5f92fa06.png)

I also added the link to the new page on the homepage as a separate card.

![image](https://user-images.githubusercontent.com/45357601/185376896-3156d731-2587-49c0-86d2-44854b254db8.png)


**Note:** Adding the new form to the `/contact` route, the business card page is moved to `/card` route now.

Let me know if you need any more changes.